### PR TITLE
Fix shell adapter by making it safe against a nil chat.Robot at init.

### DIFF
--- a/pkg/chat/shell/shell.go
+++ b/pkg/chat/shell/shell.go
@@ -45,7 +45,7 @@ func init() {
 			lines: make(chan string),
 			botUser: &chat.BaseUser{
 				UserID:    id,
-				UserName:  r.Name(),
+				UserName:  "unknown",
 				UserIsBot: true,
 			},
 		}


### PR DESCRIPTION
When I tried to use the shell adapter (which I rely on for sniff tests before pushing my bot to production), I'd get a panic at the line I changed due to the `chat.Robot` being nil.

The shell adapter worked after I made this change.
